### PR TITLE
Added handlebars templating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ structopt-derive = "0.1.6"
 mime_guess = "1.8.3"
 env_logger = "0.5.0-rc.2"
 log = "0.4.1"
+handlebars = "0.29.1"
 
 [dependencies.mdbook]
 git = "https://github.com/rust-lang-nursery/mdbook"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
-use failure::Error;
+use std::io::Read;
+use std::fs::File;
+use failure::{Error, ResultExt};
 use mdbook::renderer::RenderContext;
+
+pub const DEFAULT_TEMPLATE: &'static str = include_str!("index.hbs");
 
 /// The configuration struct used to tweak how an EPUB document is generated.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -10,6 +14,9 @@ pub struct Config {
     pub additional_css: Vec<PathBuf>,
     /// Should we use the default stylesheet (default: true)?
     pub use_default_css: bool,
+    /// The template file to use when rendering individual chapters (relative
+    /// to the book root).
+    pub index_template: Option<PathBuf>,
 }
 
 impl Config {
@@ -17,8 +24,33 @@ impl Config {
     /// falling back to the default if
     pub fn from_render_context(ctx: &RenderContext) -> Result<Config, Error> {
         match ctx.config.get("output.epub") {
-            Some(table) => table.clone().try_into().map_err(|e| Error::from(e)),
+            Some(table) => {
+                let mut cfg: Config = table.clone().try_into()?;
+
+                // make sure we update the `index_template` to make it relative
+                // to the book root
+                if let Some(template_file) = cfg.index_template.take() {
+                    cfg.index_template = Some(ctx.root.join(template_file));
+                }
+
+                Ok(cfg)
+            }
             None => Ok(Config::default()),
+        }
+    }
+
+    pub fn template(&self) -> Result<String, Error> {
+        match self.index_template {
+            Some(ref filename) => {
+                let mut buffer = String::new();
+                File::open(filename)
+                    .with_context(|_| format!("Unable to open template ({})", filename.display()))?
+                    .read_to_string(&mut buffer)
+                    .context("Unable to read the template file")?;
+
+                Ok(buffer)
+            }
+            None => Ok(DEFAULT_TEMPLATE.to_string()),
         }
     }
 }
@@ -28,6 +60,7 @@ impl Default for Config {
         Config {
             use_default_css: true,
             additional_css: Vec::new(),
+            index_template: None,
         }
     }
 }

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>{{ title }}</title>
-    <link rel="stylesheet" href="stylesheet.css" />
+    <link rel="stylesheet" href="{{ stylesheet }}" />
 </head>
 
 <body>

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -1,0 +1,13 @@
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="stylesheet.css" />
+</head>
+
+<body>
+    {{{ body }}}
+</body>
+
+</html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate epub_builder;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
+extern crate handlebars;
 #[macro_use]
 extern crate log;
 extern crate mdbook;
@@ -13,6 +14,7 @@ extern crate semver;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 
 use std::fs::{create_dir_all, File};

--- a/tests/dummy/book.toml
+++ b/tests/dummy/book.toml
@@ -1,4 +1,5 @@
 [book]
+title = "Dummy Book"
 authors = []
 multilingual = false
 src = "src"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,6 +5,7 @@ extern crate mdbook_epub;
 extern crate tempdir;
 
 use std::path::Path;
+use std::process::Command;
 use failure::{Error, SyncFailure};
 use tempdir::TempDir;
 use epub::doc::EpubDoc;
@@ -41,6 +42,28 @@ fn output_epub_is_valid() {
     let got = EpubDoc::new(&output_file);
 
     assert!(got.is_ok());
+
+    // also try to run epubcheck, if it's available
+    epub_check(&output_file).unwrap();
+}
+
+fn epub_check(path: &Path) -> Result<(), Error> {
+    let cmd = Command::new("epubcheck").arg(path).output();
+
+    match cmd {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(())
+            } else {
+                let msg = failure::err_msg(format!("epubcheck failed\n{:?}", output));
+                Err(msg)
+            }
+        }
+        Err(_) => {
+            // failed to launch epubcheck, it's probably not installed
+            Ok(())
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
This is an alternative to #5 and fixes #3 (hopefully).

I've added a simple handlebars template with the user being able to override the actual index template that is used. At the moment we just pass in the `title` and `body` (rendered HTML)
for a chapter, although this can easily be expanded in the future.

One concern I have is the CSS link to the stylesheet will be broken for nested chapters. Some time in the future we'll probably want to look at passing in the stylesheet's location as part of the template context.

`epubcheck` now passes without any errors :tada: 