### PR TITLE
#11 fix path separator mix-up on windows

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -82,7 +82,7 @@ fn assets_in_markdown(src: &str, parent_dir: &Path) -> Result<Vec<PathBuf>, Erro
     let mut assets = Vec::new();
 
     for link in found {
-        let link = PathBuf::from(link);
+        let link = PathBuf::from(normalize_path_sep(link));
         let filename = parent_dir.join(link);
         let filename = filename.canonicalize().with_context(|_| {
             format!(
@@ -102,6 +102,14 @@ fn assets_in_markdown(src: &str, parent_dir: &Path) -> Result<Vec<PathBuf>, Erro
     }
 
     Ok(assets)
+}
+
+fn normalize_path_sep(s: String) -> String {
+    if std::path::MAIN_SEPARATOR == '\\' {
+        s.replace('/', "\\")
+    } else {
+        s
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request fixes the error described in #11.

I got the same issue as #11 when building ["The Rust Programming Language" book](https://github.com/rust-lang/book) on Windows 10.

```
PS C:\Users\user1\repo\rust\book> mdbook-epub --standalone .
Error: Inspecting the book for additional assets failed
        Caused By: Unable to fetch the canonical path for \\?\C:\Users\user1\repo\rust\book\src\img/trpl20-01.png
        Caused By: The filename, directory name, or volume label syntax is incorrect. (os error 123)
```

After applying the change, mdbook-epub successfully generated the epub file as below.

```
PS C:\Users\user1\repo\rust\book> ..\mdbook-epub_fork\target\debug\mdbook-epub.exe --standalone .
PS C:\Users\user1\repo\rust\book> ls .\book\


    Directory: C:\Users\user1\repo\rust\book\book


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         4/19/2021   1:08 PM         450388 The Rust Programming Language.epub
```

The change is simply replacing / to \\ in links only when the path separator is \\ on the platform, which is currently only Windows. https://doc.rust-lang.org/std/path/constant.MAIN_SEPARATOR.html