### PR TITLE
Fix some .md links do not converted to .html

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ mdbook = { version = "0.4", default-features = false }
 handlebars = "4.2"
 toml = "0.5"
 html_parser = "0.6.2"
+lazy_static = "1.0"
+regex = "1.5.5"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! A `mdbook` backend for generating a book in the `EPUB` format.
 
 use ::epub_builder;
-use ::thiserror::Error;
 use ::handlebars;
+use ::thiserror::Error;
 #[macro_use]
 extern crate log;
 use ::mdbook;
@@ -94,7 +94,9 @@ fn version_check(ctx: &RenderContext) -> Result<(), Error> {
 
     if !required_version.matches(&provided_version) {
         Err(Error::IncompatibleVersion(
-            MDBOOK_VERSION.to_string(), ctx.version.clone()))
+            MDBOOK_VERSION.to_string(),
+            ctx.version.clone(),
+        ))
     } else {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ extern crate log;
 use ::mdbook;
 use ::semver;
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;

--- a/tests/dummy/src/SUMMARY.md
+++ b/tests/dummy/src/SUMMARY.md
@@ -1,3 +1,4 @@
 # Summary
 
+- [Introduction](intro.md)
 - [Chapter 1](./chapter_1.md)

--- a/tests/dummy/src/intro.md
+++ b/tests/dummy/src/intro.md
@@ -1,0 +1,2 @@
+# Introduction
+- [Chapter 1](chapter_1.md): DON'T PANIC"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -168,6 +168,30 @@ fn straight_quotes_transformed_into_curly_quotes() {
     assert!(content.contains("<p>“One morning, when Gregor Samsa woke from troubled dreams, he found himself ‘transformed’ in his bed into a horrible vermin.”</p>"));
 }
 
+#[test]
+#[serial]
+fn page_local_md_link_transformed_into_html_ext() {
+    init_logging();
+    debug!("page_local_md_link_transformed_into_html_link...");
+    let (mut doc, doc_path) = generate_epub().unwrap();
+    debug!("doc current path = {:?}", doc_path);
+
+    let intro_path = "intro.html";
+    let path;
+    if cfg!(target_os = "linux") {
+        path = Path::new("OEBPS").join(intro_path); // linux
+    } else {
+        path = Path::new("OEBPS/").join(intro_path).to_path_buf(); // windows with 'forward slash' /
+    }
+
+    let content = doc.get_resource_str_by_path(path).unwrap();
+    debug!("content = {:?}", content);
+    assert!(
+        content.contains("chapter_1.html"),
+        "Link chapter_1.md should be transformed"
+    );
+}
+
 /// Use `MDBook::load()` to load the dummy book into memory, then set up the
 /// `RenderContext` for use the EPUB generator.
 fn create_dummy_book() -> Result<(RenderContext, MDBook, TempDir), Error> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,21 +1,21 @@
 use ::epub;
-use std::env;
 use ::mdbook;
 use ::mdbook_epub;
 use ::tempdir;
+use std::env;
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serial_test;
 
 use epub::doc::EpubDoc;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use tempdir::TempDir;
-use std::sync::Once;
 use mdbook::renderer::RenderContext;
 use mdbook::MDBook;
 use mdbook_epub::Error;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Once;
+use tempdir::TempDir;
 
 static INIT: Once = Once::new();
 
@@ -26,7 +26,7 @@ fn init_logging() {
 }
 
 /// Convenience function for compiling the dummy book into an `EpubDoc`.
-fn generate_epub() -> Result< (EpubDoc, PathBuf), Error> {
+fn generate_epub() -> Result<(EpubDoc, PathBuf), Error> {
     let (ctx, _md, temp) = create_dummy_book().unwrap();
     debug!("temp dir = {:?}", &temp);
     mdbook_epub::generate(&ctx)?;
@@ -37,11 +37,12 @@ fn generate_epub() -> Result< (EpubDoc, PathBuf), Error> {
     match EpubDoc::new(&output_file) {
         Ok(epub) => {
             let result: (EpubDoc, PathBuf) = (epub, output_file);
-            return Ok( result )},
+            return Ok(result);
+        }
         Err(err) => {
             error!("dummy book creation error = {}", err);
-            return Err(Error::EpubDocCreate(output_file.display().to_string()))?
-        },
+            return Err(Error::EpubDocCreate(output_file.display().to_string()))?;
+        }
     }
 }
 
@@ -126,7 +127,11 @@ fn rendered_document_contains_all_chapter_files_and_assets() {
     debug!("rendered_document_contains_all_chapter_files_and_assets...");
     let chapters = vec!["chapter_1.html", "rust-logo.png"];
     let mut doc = generate_epub().unwrap();
-    debug!("doc current path = {:?} / {:?}", doc.0.get_current_path(), doc.1);
+    debug!(
+        "doc current path = {:?} / {:?}",
+        doc.0.get_current_path(),
+        doc.1
+    );
 
     for chapter in chapters {
         let path;
@@ -162,7 +167,6 @@ fn straight_quotes_transformed_into_curly_quotes() {
     debug!("content = {:?}", content);
     assert!(content.contains("<p>“One morning, when Gregor Samsa woke from troubled dreams, he found himself ‘transformed’ in his bed into a horrible vermin.”</p>"));
 }
-
 
 /// Use `MDBook::load()` to load the dummy book into memory, then set up the
 /// `RenderContext` for use the EPUB generator.


### PR DESCRIPTION
When create the book for [rust-unofficial/too-many-lists](https://github.com/dieterplex/too-many-lists), `.md` links of some pages do not convert to `.html` like `README.md`.

This work 
- use a simplified utility function [adjust_links()](https://github.com/rust-lang/mdBook/blob/master/src/utils/mod.rs#L75) from `mdbook` to fix the links
- run rustfmt to changed files
- add a test case to verify link