### PR TITLE
Escape titles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ name = "mdbook-epub"
 doc = false
 
 [dependencies]
-epub-builder = "0.5"
+epub-builder = "0.5.0"
 thiserror = "1.0"
 pulldown-cmark = "0.9"
-semver = "0.11"
+semver = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
 mime_guess = "2.0"
-env_logger = "0.7"
+env_logger = "0.9.0"
 log = "0.4"
 mdbook = { version = "0.4", default-features = false }
 handlebars = "4.2"
@@ -42,4 +42,4 @@ html_parser = "0.6.2"
 [dev-dependencies]
 tempdir = "0.3.7"
 epub = "1.2"
-serial_test = "0.5"
+serial_test = "0.6.0"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -339,13 +339,15 @@ impl EventQuoteConverter {
 }
 
 struct EventCodeConverter {
-    convert_code: bool
+    convert_code: bool,
+    in_html: bool,
 }
 
 impl EventCodeConverter {
     fn new() -> Self {
         EventCodeConverter {
-            convert_code: false
+            convert_code: false,
+            in_html: false,
         }
     }
 
@@ -364,6 +366,19 @@ impl EventCodeConverter {
             }
             Event::Code(ref text) => {
                 Event::Code(CowStr::from(text.lines().filter(|line| !line.starts_with("# ")).collect::<Vec<&str>>().join("\n").replace("    ", "  ")))
+            },
+            Event::Html(ref text) => {
+                if text.trim_start().starts_with("<!--") {
+                    self.in_html = true;
+                }
+                if text.trim_end().ends_with("-->") {
+                    self.in_html = false;
+                }
+                if self.in_html || text.trim_start().starts_with("<!--") || text.trim_end().ends_with("-->") {
+                    Event::Html(CowStr::from(""))
+                } else {
+                    event
+                }
             }
             _ => event,
         }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -104,7 +104,7 @@ impl<'a> Generator<'a> {
 
         let content_path = ch.path.as_ref()
             .ok_or_else(|| Error::ContentFileNotFound(format!("Content file was not found for Chapter {}", ch.name)))?;
-            trace!("add a chapter {:?} by a path = {:?}", &ch.name, content_path);
+        trace!("add a chapter {:?} by a path = {:?}", &ch.name, content_path);
         let path = content_path.with_extension("html").display().to_string();
         let title = format!("{}", ch);
         let mut titleclean = String::new();

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -8,7 +8,7 @@ use std::{iter,
 use mdbook::renderer::RenderContext;
 use mdbook::book::{BookItem, Chapter};
 use epub_builder::{EpubBuilder, EpubContent, ZipLibrary};
-use pulldown_cmark::{html, Parser, Options, Event, CowStr, Tag};
+use pulldown_cmark::{html, Parser, Options, Event, CowStr, Tag, escape};
 use super::Error;
 use handlebars::{Handlebars, RenderError};
 
@@ -104,9 +104,12 @@ impl<'a> Generator<'a> {
 
         let content_path = ch.path.as_ref()
             .ok_or_else(|| Error::ContentFileNotFound(format!("Content file was not found for Chapter {}", ch.name)))?;
-        trace!("add a chapter {:?} by a path = {:?}", &ch.name, content_path);
+            trace!("add a chapter {:?} by a path = {:?}", &ch.name, content_path);
         let path = content_path.with_extension("html").display().to_string();
-        let mut content = EpubContent::new(path, rendered.as_bytes()).title(format!("{}", ch));
+        let title = format!("{}", ch);
+        let mut titleclean = String::new();
+        escape::escape_html(&mut titleclean, &title).unwrap();
+        let mut content = EpubContent::new(path, rendered.as_bytes()).title(titleclean);
 
         let level = ch.number.as_ref().map(|n| n.len() as i32 - 1).unwrap_or(0);
         content = content.level(level);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,7 @@ pub enum Error {
     #[error(transparent)]
     Book(#[from] mdbook::errors::Error),
     #[error(transparent)]
-    Semver(#[from] semver::SemVerError),
-    #[error(transparent)]
-    SemverReqParse(#[from] semver::ReqParseError),
+    Semver(#[from] semver::Error),
     #[error(transparent)]
     EpubBuilder(#[from] epub_builder::Error),
     #[error(transparent)]


### PR DESCRIPTION
When "the book" is converted titles with arrows cause validation errors.
This change escapes all titles before setting them in the epub.