### PR TITLE
Improve log message for finding assets

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -111,7 +111,7 @@ impl<'a> Generator<'a> {
         // resources::find can emit very unclear error based on internal MD content,
         // so let's give a tip to user in error message
         let assets = resources::find(self.ctx).map_err(|e| {
-            error!("{}", error);
+            error!("{} Caused by: {}", error, e);
             e
         })?;
         self.assets.extend(assets);


### PR DESCRIPTION
While building a book, I found that even an asset not found is not obviously to find where the error is. So it would be helpful if the log line looks like below:

```
[2023-02-20T14:24:20Z ERROR mdbook_epub::generator] Failed finding/fetch resource taken from content? Look up content for possible error... Caused by: Asset was not found: ../../img/kimchi.png
```

Context: https://github.com/o1-labs/proof-systems/pull/1022

