### PR TITLE
bump to stable 0.4.32 version after check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 description = "An EPUB renderer for mdbook."
 name = "mdbook-epub"
-version = "0.4.32-beta1"
+version = "0.4.32"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/Michael-F-Bryan/mdbook-epub"


### PR DESCRIPTION
Code is checked with command
`cargo install mdbook-epub@0.4.32-beta1`
there is no error. So version is bumpled to 0.4.32 and will be published.