### PR TITLE
fix for non ascii chars in remote url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "toml",
  "ureq",
  "url",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1683,6 +1684,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ toml = "0.5.11" # downgraded due to parent 'mdbook' dependency and error there
 html_parser = "0.7.0"
 url = "2.3"
 ureq = "2.9"
+urlencoding = "2.1.3"
 const_format = "0.2.31"
 uuid = "1.8"
 

--- a/tests/dummy/src/chapter_1.md
+++ b/tests/dummy/src/chapter_1.md
@@ -1,5 +1,7 @@
 # Chapter 1
 
+<img src="https://github.com/sunface/rust-course/blob/main/assets/studyrust公众号.png?raw=true" />
+
 Here is the Rust logo:
 
 ![Rust Logo](rust-logo.png)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -134,7 +134,7 @@ fn rendered_document_contains_all_chapter_files_and_assets() {
     let mut doc = generate_epub().unwrap();
     debug!("Number of internal epub resources = {:?}", doc.0.resources);
     // number of internal epub resources for dummy test book
-    assert_eq!(9, doc.0.resources.len());
+    assert_eq!(10, doc.0.resources.len());
     assert_eq!(2, doc.0.spine.len());
     assert_eq!(doc.0.mdata("title").unwrap(), "DummyBook");
     assert_eq!(doc.0.mdata("language").unwrap(), "en");


### PR DESCRIPTION
Fixed remote resource url processing when it has a 'non ascii' chars inside