### PR TITLE
turn on CI on all the branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,7 @@ name: Rust
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:


### PR DESCRIPTION
So people working on pull-request in branches will be able to enable GitHub Actions and benefit from it.