### PR TITLE
fix: image not found in README.md while mdbook build

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use std::path::PathBuf;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -41,6 +41,9 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    AssetOutsideSrcDir(#[from] std::path::StripPrefixError),
 
     #[error(transparent)]
     Book(#[from] mdbook::errors::Error),

--- a/tests/dummy/src/02_advanced/Epub_logo.svg
+++ b/tests/dummy/src/02_advanced/Epub_logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="600px" height="600px" viewBox="0 0 600 600" enable-background="new 0 0 600 600" xml:space="preserve">
+<path fill="#86B918" d="M298.549,467.913L129.228,298.579L298.549,129.27l56.446,56.435L242.104,298.579l56.441,56.443
+	l169.323-169.309L320.366,38.217c-12.043-12.055-31.579-12.055-43.634,0L38.169,276.781c-12.044,12.043-12.044,31.58,0,43.633
+	l238.563,238.558c12.055,12.05,31.591,12.05,43.634,0l238.564-238.558c12.044-12.053,12.044-31.59,0-43.633L524.3,242.159
+	L298.549,467.913z"/>
+</svg>

--- a/tests/dummy/src/02_advanced/README.md
+++ b/tests/dummy/src/02_advanced/README.md
@@ -1,0 +1,5 @@
+# README.md tests
+
+## image link
+
+![Awesome image in the same folder](Epub_logo.svg "Awesome")

--- a/tests/dummy/src/SUMMARY.md
+++ b/tests/dummy/src/SUMMARY.md
@@ -2,3 +2,7 @@
 
 - [Chapter 1](./chapter_1.md)
   - [Getting started](01_getting_started/02_article.md)
+
+# Advanced
+
+- [README.md tests](./02_advanced/README.md)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -127,15 +127,36 @@ fn look_for_chapter_1_heading() {
 
 #[test]
 #[serial]
+fn look_for_chapter_2_image_link_in_readme() {
+    init_logging();
+    let mut doc = generate_epub().unwrap();
+
+    let path = if cfg!(target_os = "linux") {
+        Path::new("OEBPS").join("02_advanced").join("README.html") // linux
+    } else {
+        Path::new("OEBPS/02_advanced/README.html").to_path_buf() // windows with 'forward slash' /
+    };
+    let content = doc.0.get_resource_str_by_path(path).unwrap();
+
+    assert!(content.contains("<img src=\"Epub_logo.svg\""));
+}
+
+#[test]
+#[serial]
 fn rendered_document_contains_all_chapter_files_and_assets() {
     init_logging();
     debug!("rendered_document_contains_all_chapter_files_and_assets...");
-    let chapters = vec!["chapter_1.html", "rust-logo.png"];
+    let chapters = vec![
+        "chapter_1.html",
+        "rust-logo.png",
+        "02_advanced/README.html",
+        "02_advanced/Epub_logo.svg",
+    ];
     let mut doc = generate_epub().unwrap();
     debug!("Number of internal epub resources = {:?}", doc.0.resources);
     // number of internal epub resources for dummy test book
-    assert_eq!(10, doc.0.resources.len());
-    assert_eq!(2, doc.0.spine.len());
+    assert_eq!(12, doc.0.resources.len());
+    assert_eq!(3, doc.0.spine.len());
     assert_eq!(doc.0.mdata("title").unwrap(), "DummyBook");
     assert_eq!(doc.0.mdata("language").unwrap(), "en");
     debug!(


### PR DESCRIPTION
Fix #115

- Adjust the root of `README.md` chapter when running as a preprocessor and links preprocessor enabled
- Referenced image is not showed due to resources added to wrong path