### PR TITLE
Add config to allow collecting assets outside book's src dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Recognized options:
 `additional-resources`: A list of path to files which should be added to the
 EPUB, such as typefaces. They will be added with path `OEBPS/<filename>`.
 
+`allow-assets-outside-book-src-dir`: Allow local assets linked from markdown to
+be collected even when they resolve outside the book's `src/` directory.
+
 `no-section-label`: In the contents list, don't prefix the chapter title with
 its section number.
 
@@ -87,6 +90,7 @@ additional-css = ["./path/to/main.css"]
 use-default-css = false
 cover-image = "ebook-cover.png"
 additional-resources = ["./assets/Open-Sans-Regular.ttf"]
+allow-assets-outside-book-src-dir = true
 no-section-label = true
 curly-quotes = true
 epub-version = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub no_section_label: bool,
     /// Use "smart quotes" instead of the usual `"` character.
     pub curly_quotes: bool,
+    /// Allow collecting linked local assets that are outside the book `src/` directory.
+    pub allow_assets_outside_book_src_dir: bool,
     /// Add backreference links to footnote definitions and allow pop-up footnote behaviour.
     /// Requires `epub-version = 3`, in which case it is enabled by default.
     pub footnote_backrefs: bool,
@@ -72,6 +74,7 @@ impl Default for Config {
             additional_resources: Vec::new(),
             no_section_label: false,
             curly_quotes: false,
+            allow_assets_outside_book_src_dir: false,
             footnote_backrefs: false,
             epub_version: None,
         }
@@ -96,6 +99,35 @@ mod tests {
         let ctx = RenderContext::from_json(json.as_bytes()).unwrap();
         let config = Config::from_render_context(&ctx);
         assert!(config.is_ok());
+        assert!(!config.unwrap().allow_assets_outside_book_src_dir);
+    }
+
+    #[test]
+    fn test_from_render_context_allow_assets_outside_book_src_dir() {
+        let json = json!({
+            "version": mdbook_core::MDBOOK_VERSION,
+            "root": "tests/long_book_example",
+            "book": {"items": [], "__non_exhaustive": null},
+            "config": {
+                "book": {
+                    "authors": [],
+                    "language": "en",
+                    "text-direction": "ltr",
+                    "src": "src",
+                    "title": "DummyBook"
+                },
+                "output": {
+                    "epub": {
+                        "allow-assets-outside-book-src-dir": true
+                    }
+                }
+            },
+            "destination": "book/epub"
+        })
+        .to_string();
+        let ctx = RenderContext::from_json(json.as_bytes()).unwrap();
+        let config = Config::from_render_context(&ctx).unwrap();
+        assert!(config.allow_assets_outside_book_src_dir);
     }
 
     fn ctx_with_template(source: &str, destination: &Path) -> serde_json::Value {

--- a/src/resources/asset.rs
+++ b/src/resources/asset.rs
@@ -99,6 +99,7 @@ impl Asset {
         link: &str,
         src_dir: &Path,
         chapter_path: &Path,
+        allow_outside_src_dir: bool,
     ) -> Result<Asset, Error> {
         debug!(
             "Composing asset path for {:?} + {:?} in chapter = {:?}",
@@ -128,7 +129,12 @@ impl Asset {
             return Err(Error::AssetFile(absolute_location));
         }
         // Use filename as embedded file path with content from absolute_location.
-        let filename = full_filename.strip_prefix(src_dir)?;
+        // By default this must be relative to `src/`, but it may be outside when explicitly allowed.
+        let filename = match full_filename.strip_prefix(src_dir) {
+            Ok(filename) => filename.to_path_buf(),
+            Err(_error) if allow_outside_src_dir => utils::normalize_path(Path::new(link)),
+            Err(error) => return Err(Error::AssetOutsideSrcDir(error)),
+        };
 
         let asset = Asset::new(
             link,

--- a/src/resources/resource.rs
+++ b/src/resources/resource.rs
@@ -10,7 +10,7 @@ use tracing::{debug, trace, warn};
 use url::Url;
 
 use crate::resources::asset::{Asset, AssetKind};
-use crate::{Error, utils, path_io};
+use crate::{Config, Error, path_io, utils};
 
 // Internal constants for reveling 'upper folder' paths in resource links inside MD
 pub(crate) const UPPER_PARENT: &str = concatcp!("..", MAIN_SEPARATOR_STR);
@@ -35,6 +35,8 @@ pub(crate) fn find(ctx: &RenderContext) -> Result<HashMap<String, Asset>, Error>
     let mut assets: HashMap<String, Asset> = HashMap::new();
     debug!("Finding resources by:\n{:?}", ctx.config);
     let src_dir = path_io(ctx.root.join(&ctx.config.book.src).canonicalize(), &ctx.config.book.src)?;
+    let allow_assets_outside_src_dir =
+        Config::from_render_context(ctx)?.allow_assets_outside_book_src_dir;
 
     debug!(
         "Start iteration over a [{:?}] sections in src_dir = {:?}",
@@ -55,7 +57,12 @@ pub(crate) fn find(ctx: &RenderContext) -> Result<HashMap<String, Asset>, Error>
                     let asset = if let Ok(url) = Url::parse(&link) {
                         Asset::from_url(&link, url, &ctx.destination)
                     } else {
-                        let result = Asset::from_local(&link, &src_dir, ch.path.as_ref().unwrap());
+                        let result = Asset::from_local(
+                            &link,
+                            &src_dir,
+                            ch.path.as_ref().unwrap(),
+                            allow_assets_outside_src_dir,
+                        );
                         if let Err(Error::AssetOutsideSrcDir(_)) = result {
                             warn!("Asset '{link}' is outside source dir '{src_dir:?}' and ignored");
                             continue;
@@ -71,30 +78,24 @@ pub(crate) fn find(ctx: &RenderContext) -> Result<HashMap<String, Asset>, Error>
                     match asset.source {
                         // local asset kind
                         AssetKind::Local(_) => {
-                            let relative = asset.location_on_disk.strip_prefix(&src_dir);
-                            match relative {
-                                Ok(_relative_link_path) => {
-                                    let link_key = asset.original_link.clone();
-                                    if let std::collections::hash_map::Entry::Vacant(e) =
-                                        assets.entry(link_key.to_owned())
-                                    {
-                                        debug!(
-                                            "Adding asset by link '{:?}' : {}",
-                                            link_key, &asset
-                                        );
-                                        e.insert(asset);
-                                        assets_count += 1;
-                                    } else {
-                                        debug!("Skipped asset for '{}'", link_key);
-                                    }
+                            let inside_src = asset.location_on_disk.strip_prefix(&src_dir).is_ok();
+                            if inside_src || allow_assets_outside_src_dir {
+                                let link_key = asset.original_link.clone();
+                                if let std::collections::hash_map::Entry::Vacant(e) =
+                                    assets.entry(link_key.to_owned())
+                                {
+                                    debug!("Adding asset by link '{:?}' : {}", link_key, &asset);
+                                    e.insert(asset);
+                                    assets_count += 1;
+                                } else {
+                                    debug!("Skipped asset for '{}'", link_key);
                                 }
-                                _ => {
-                                    // skip incorrect resource/image link outside of book /SRC/ folder
-                                    warn!(
-                                        "Sorry, we can't add 'Local asset' that is outside of book's /src/ folder, {:?}",
-                                        &asset
-                                    );
-                                }
+                            } else {
+                                // skip incorrect resource/image link outside of book /SRC/ folder
+                                warn!(
+                                    "Sorry, we can't add 'Local asset' that is outside of book's /src/ folder, {:?}",
+                                    &asset
+                                );
                             }
                         }
                         AssetKind::Remote(_) => {
@@ -274,6 +275,42 @@ mod tests {
     }
 
     #[test]
+    fn test_find_local_asset_outside_src_when_enabled() {
+        let inside_link = "./rust-logo.png";
+        let outside_link = "../third_party/wikimedia/Epub_logo_color.svg";
+
+        let tmp_dir = TempDir::new().unwrap();
+        let temp = tmp_dir.path().join("mdbook-epub");
+        let dest_dir = temp.as_path().to_string_lossy().to_string();
+        let chapters = json!([{
+            "Chapter": {
+                "name": "Chapter 1",
+                "content": format!("# Chapter 1\r\n\r\n![Image]({inside_link})\r\n![Image]({outside_link})"),
+                "number": [1],
+                "sub_items": [],
+                "path": "chapter_1.md",
+                "parent_names": []
+            }
+        }]);
+        let ctx = ctx_with_chapters_allow_assets_outside(&chapters, &dest_dir, true).unwrap();
+
+        let mut assets = find(&ctx).unwrap();
+        assert_eq!(2, assets.len());
+
+        let outside_asset = assets.remove(outside_link).unwrap();
+        let expected_outside_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/long_book_example/third_party/wikimedia/Epub_logo_color.svg")
+            .canonicalize()
+            .unwrap();
+
+        assert_eq!(outside_asset.location_on_disk, expected_outside_path);
+        assert_eq!(
+            outside_asset.filename,
+            PathBuf::from("third_party/wikimedia/Epub_logo_color.svg")
+        );
+    }
+
+    #[test]
     fn test_find_remote_asset() {
         let link = "https://www.rust-lang.org/static/images/rust-logo-blk.svg";
         let link2 = "https://www.rust-lang.org/static/images/rust-logo-blk.png";
@@ -345,7 +382,8 @@ mod tests {
             Asset::from_local(
                 "a.png",
                 Path::new("tests\\dummy\\src"),
-                Path::new("ch\\a.md")
+                Path::new("ch\\a.md"),
+                false,
             )
             .unwrap_err()
             .to_string()
@@ -361,7 +399,8 @@ mod tests {
             Asset::from_local(
                 "a.png",
                 Path::new("tests/long_book_example/src"),
-                Path::new("ch/a.md")
+                Path::new("ch/a.md"),
+                false,
             )
             .unwrap_err()
             .to_string()
@@ -379,7 +418,8 @@ mod tests {
             Asset::from_local(
                 "wikimedia",
                 Path::new("tests/long_book_example"),
-                Path::new("third_party/a.md")
+                Path::new("third_party/a.md"),
+                false,
             )
             .unwrap_err()
             .to_string()
@@ -398,7 +438,8 @@ mod tests {
             Asset::from_local(
                 "wikimedia",
                 Path::new("tests\\dummy"),
-                Path::new("third_party\\a.md")
+                Path::new("third_party\\a.md"),
+                false,
             )
             .unwrap_err()
             .to_string()
@@ -409,6 +450,14 @@ mod tests {
         chapters: &Value,
         destination: &str,
     ) -> Result<RenderContext, mdbook_core::errors::Error> {
+        ctx_with_chapters_allow_assets_outside(chapters, destination, false)
+    }
+
+    fn ctx_with_chapters_allow_assets_outside(
+        chapters: &Value,
+        destination: &str,
+        allow_assets_outside_book_src_dir: bool,
+    ) -> Result<RenderContext, mdbook_core::errors::Error> {
         let json_ctx = json!({
             "version": mdbook_core::MDBOOK_VERSION,
             "root": "tests/long_book_example",
@@ -416,7 +465,10 @@ mod tests {
             "config": {
                 "book": {"authors": [], "language": "en", "text-direction": "ltr",
                     "src": "src", "title": "DummyBook"},
-                "output": {"epub": {"curly-quotes": true}}},
+                "output": {"epub": {
+                    "curly-quotes": true,
+                    "allow-assets-outside-book-src-dir": allow_assets_outside_book_src_dir
+                }}},
             "destination": destination
         });
         RenderContext::from_json(json_ctx.to_string().as_bytes())


### PR DESCRIPTION
Previously, any local assets outside of the book's `src/` dir were rejected in `resource::find()`.

Searching with `git log -G ...` shows this behavior originating in c1d7bd75 in July 2023, but the earliest I can find with a bit more digging is 97e0a309 a little before in May.

This is problematic for more complex configurations where assets may be kept in a separate directory hierarchy, parallel to the actual book source (the motivating example for me happened to be the [Dioxus docsite](https://github.com/DioxusLabs/docsite)).

This commit introduces a new, Boolean config setting, `allow-assets-outside-book-src-dir`, which can be used to indicate that local assets outside of the book's `src/` dir are allowed. Defaults to `false`, matching previous behavior. Tests included.